### PR TITLE
feat(channel): add pass-through request headers toggle

### DIFF
--- a/dto/channel_settings.go
+++ b/dto/channel_settings.go
@@ -1,12 +1,13 @@
 package dto
 
 type ChannelSettings struct {
-	ForceFormat            bool   `json:"force_format,omitempty"`
-	ThinkingToContent      bool   `json:"thinking_to_content,omitempty"`
-	Proxy                  string `json:"proxy"`
-	PassThroughBodyEnabled bool   `json:"pass_through_body_enabled,omitempty"`
-	SystemPrompt           string `json:"system_prompt,omitempty"`
-	SystemPromptOverride   bool   `json:"system_prompt_override,omitempty"`
+	ForceFormat              bool   `json:"force_format,omitempty"`
+	ThinkingToContent        bool   `json:"thinking_to_content,omitempty"`
+	Proxy                    string `json:"proxy"`
+	PassThroughHeaderEnabled bool   `json:"pass_through_header_enabled,omitempty"`
+	PassThroughBodyEnabled   bool   `json:"pass_through_body_enabled,omitempty"`
+	SystemPrompt             string `json:"system_prompt,omitempty"`
+	SystemPromptOverride     bool   `json:"system_prompt_override,omitempty"`
 }
 
 type VertexKeyType string

--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -24,6 +24,23 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+var defaultPassThroughHeaderDenySet = map[string]struct{}{
+	"authorization":       {},
+	"api-key":             {},
+	"x-api-key":           {},
+	"connection":          {},
+	"keep-alive":          {},
+	"proxy-authenticate":  {},
+	"proxy-authorization": {},
+	"te":                  {},
+	"trailer":             {},
+	"transfer-encoding":   {},
+	"upgrade":             {},
+	"proxy-connection":    {},
+	"host":                {},
+	"content-length":      {},
+}
+
 func SetupApiRequestHeader(info *common.RelayInfo, c *gin.Context, req *http.Header) {
 	if info.RelayMode == constant.RelayModeAudioTranscription || info.RelayMode == constant.RelayModeAudioTranslation {
 		// multipart/form-data
@@ -79,21 +96,9 @@ func applyPassThroughRequestHeadersIfEnabled(c *gin.Context, info *common.RelayI
 }
 
 func buildPassThroughHeaderDenySet(src http.Header, extraDeny []string) map[string]struct{} {
-	deny := map[string]struct{}{
-		"authorization":       {},
-		"api-key":             {},
-		"x-api-key":           {},
-		"connection":          {},
-		"keep-alive":          {},
-		"proxy-authenticate":  {},
-		"proxy-authorization": {},
-		"te":                  {},
-		"trailer":             {},
-		"transfer-encoding":   {},
-		"upgrade":             {},
-		"proxy-connection":    {},
-		"host":                {},
-		"content-length":      {},
+	deny := make(map[string]struct{}, len(defaultPassThroughHeaderDenySet)+len(extraDeny)+4)
+	for k := range defaultPassThroughHeaderDenySet {
+		deny[k] = struct{}{}
 	}
 
 	// Connection: token1, token2

--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -28,6 +28,7 @@ var defaultPassThroughHeaderDenySet = map[string]struct{}{
 	"authorization":       {},
 	"api-key":             {},
 	"x-api-key":           {},
+	"cookie":              {},
 	"connection":          {},
 	"keep-alive":          {},
 	"proxy-authenticate":  {},
@@ -181,7 +182,7 @@ func DoFormRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBod
 	// set form data
 	req.Header.Set("Content-Type", c.Request.Header.Get("Content-Type"))
 	headers := req.Header
-	applyPassThroughRequestHeadersIfEnabled(c, info, headers, nil)
+	applyPassThroughRequestHeadersIfEnabled(c, info, headers, []string{"Content-Type"})
 	headerOverride, err := processHeaderOverride(info)
 	if err != nil {
 		return nil, err

--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -58,6 +58,77 @@ func processHeaderOverride(info *common.RelayInfo) (map[string]string, error) {
 	return headerOverride, nil
 }
 
+// applyPassThroughRequestHeadersIfEnabled 将下游请求头透传到上游请求头（最低优先级）
+//
+// - 仅当渠道开启 pass_through_header_enabled 时生效
+// - 会过滤鉴权字段与 hop-by-hop 控制头，并解析 Connection 中声明的 hop-by-hop header
+// - 透传发生在 header_override 与 adaptor.SetupRequestHeader 之前，因此优先级最低
+func applyPassThroughRequestHeadersIfEnabled(c *gin.Context, info *common.RelayInfo, dst http.Header, extraDeny []string) {
+	if info == nil || !info.ChannelSetting.PassThroughHeaderEnabled {
+		return
+	}
+	if c == nil || c.Request == nil {
+		return
+	}
+	src := c.Request.Header
+	if src == nil {
+		return
+	}
+	deny := buildPassThroughHeaderDenySet(src, extraDeny)
+	copyHeadersExcept(dst, src, deny)
+}
+
+func buildPassThroughHeaderDenySet(src http.Header, extraDeny []string) map[string]struct{} {
+	deny := map[string]struct{}{
+		"authorization":       {},
+		"api-key":             {},
+		"x-api-key":           {},
+		"connection":          {},
+		"keep-alive":          {},
+		"proxy-authenticate":  {},
+		"proxy-authorization": {},
+		"te":                  {},
+		"trailer":             {},
+		"transfer-encoding":   {},
+		"upgrade":             {},
+		"proxy-connection":    {},
+		"host":                {},
+		"content-length":      {},
+	}
+
+	// Connection: token1, token2
+	for _, v := range src.Values("Connection") {
+		for _, token := range strings.Split(v, ",") {
+			t := strings.ToLower(strings.TrimSpace(token))
+			if t == "" {
+				continue
+			}
+			deny[t] = struct{}{}
+		}
+	}
+
+	for _, h := range extraDeny {
+		t := strings.ToLower(strings.TrimSpace(h))
+		if t == "" {
+			continue
+		}
+		deny[t] = struct{}{}
+	}
+	return deny
+}
+
+func copyHeadersExcept(dst, src http.Header, deny map[string]struct{}) {
+	for k, vv := range src {
+		if len(vv) == 0 {
+			continue
+		}
+		if _, blocked := deny[strings.ToLower(k)]; blocked {
+			continue
+		}
+		dst[http.CanonicalHeaderKey(k)] = append([]string(nil), vv...)
+	}
+}
+
 func DoApiRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody io.Reader) (*http.Response, error) {
 	fullRequestURL, err := a.GetRequestURL(info)
 	if err != nil {
@@ -71,6 +142,7 @@ func DoApiRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}
 	headers := req.Header
+	applyPassThroughRequestHeadersIfEnabled(c, info, headers, nil)
 	headerOverride, err := processHeaderOverride(info)
 	if err != nil {
 		return nil, err
@@ -104,6 +176,7 @@ func DoFormRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBod
 	// set form data
 	req.Header.Set("Content-Type", c.Request.Header.Get("Content-Type"))
 	headers := req.Header
+	applyPassThroughRequestHeadersIfEnabled(c, info, headers, nil)
 	headerOverride, err := processHeaderOverride(info)
 	if err != nil {
 		return nil, err
@@ -128,6 +201,11 @@ func DoWssRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody
 		return nil, fmt.Errorf("get request url failed: %w", err)
 	}
 	targetHeader := http.Header{}
+	applyPassThroughRequestHeadersIfEnabled(c, info, targetHeader, []string{
+		"Sec-WebSocket-Key",
+		"Sec-WebSocket-Version",
+		"Sec-WebSocket-Extensions",
+	})
 	headerOverride, err := processHeaderOverride(info)
 	if err != nil {
 		return nil, err
@@ -309,6 +387,18 @@ func DoTaskApiRequest(a TaskAdaptor, c *gin.Context, info *common.RelayInfo, req
 	}
 	req.GetBody = func() (io.ReadCloser, error) {
 		return io.NopCloser(requestBody), nil
+	}
+
+	// Task 请求默认保持原行为；仅在开启“透传请求头”时才透传下游 headers（并允许 header_override 覆盖）。
+	if info != nil && info.ChannelSetting.PassThroughHeaderEnabled {
+		applyPassThroughRequestHeadersIfEnabled(c, info, req.Header, nil)
+		headerOverride, err := processHeaderOverride(info)
+		if err != nil {
+			return nil, err
+		}
+		for key, value := range headerOverride {
+			req.Header.Set(key, value)
+		}
 	}
 
 	err = a.BuildRequestHeader(c, req, info)

--- a/relay/channel/api_request_test.go
+++ b/relay/channel/api_request_test.go
@@ -16,6 +16,7 @@ func TestCopyHeadersExcept_FiltersAuthHopByHopAndConnectionTokens(t *testing.T) 
 	src.Set("Authorization", "Bearer user")
 	src.Set("api-key", "user-key")
 	src.Set("x-api-key", "user-x-key")
+	src.Set("Cookie", "session=abc")
 
 	// hop-by-hop / control headers (must be filtered)
 	src.Set("Upgrade", "websocket")
@@ -50,6 +51,7 @@ func TestCopyHeadersExcept_FiltersAuthHopByHopAndConnectionTokens(t *testing.T) 
 		"Authorization",
 		"Api-Key",
 		"X-Api-Key",
+		"Cookie",
 		"Connection",
 		"Keep-Alive",
 		"Proxy-Authenticate",
@@ -73,9 +75,9 @@ func TestBuildPassThroughHeaderDenySet_ConnectionTokensAndExtraDeny(t *testing.T
 	src := http.Header{}
 	src.Add("Connection", " X-Hop , Foo ")
 
-	deny := buildPassThroughHeaderDenySet(src, []string{"Sec-WebSocket-Key"})
+	deny := buildPassThroughHeaderDenySet(src, []string{"Sec-WebSocket-Key", "Content-Type"})
 
-	for _, k := range []string{"x-hop", "foo", "sec-websocket-key"} {
+	for _, k := range []string{"x-hop", "foo", "sec-websocket-key", "content-type"} {
 		if _, ok := deny[k]; !ok {
 			t.Fatalf("expected denyset to include %q", k)
 		}

--- a/relay/channel/api_request_test.go
+++ b/relay/channel/api_request_test.go
@@ -22,6 +22,12 @@ func TestCopyHeadersExcept_FiltersAuthHopByHopAndConnectionTokens(t *testing.T) 
 	src.Set("Transfer-Encoding", "chunked")
 	src.Set("Host", "example.com")
 	src.Set("Content-Length", "123")
+	src.Set("Keep-Alive", "timeout=5")
+	src.Set("Proxy-Authenticate", "Basic realm=\"proxy\"")
+	src.Set("Proxy-Authorization", "Basic abc")
+	src.Set("Te", "trailers")
+	src.Set("Trailer", "Foo")
+	src.Set("Proxy-Connection", "keep-alive")
 
 	// Connection declares additional hop-by-hop header names (must be filtered)
 	src.Add("Connection", "X-Hop, keep-alive")
@@ -45,8 +51,14 @@ func TestCopyHeadersExcept_FiltersAuthHopByHopAndConnectionTokens(t *testing.T) 
 		"Api-Key",
 		"X-Api-Key",
 		"Connection",
-		"Upgrade",
+		"Keep-Alive",
+		"Proxy-Authenticate",
+		"Proxy-Authorization",
+		"Te",
+		"Trailer",
 		"Transfer-Encoding",
+		"Upgrade",
+		"Proxy-Connection",
 		"Host",
 		"Content-Length",
 		"X-Hop",

--- a/relay/channel/api_request_test.go
+++ b/relay/channel/api_request_test.go
@@ -1,0 +1,71 @@
+package channel
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestCopyHeadersExcept_FiltersAuthHopByHopAndConnectionTokens(t *testing.T) {
+	src := http.Header{}
+	src.Set("X-Trace-Id", "abc")
+	src.Add("X-Multi", "a")
+	src.Add("X-Multi", "b")
+
+	// auth headers (must be filtered)
+	src.Set("Authorization", "Bearer user")
+	src.Set("api-key", "user-key")
+	src.Set("x-api-key", "user-x-key")
+
+	// hop-by-hop / control headers (must be filtered)
+	src.Set("Upgrade", "websocket")
+	src.Set("Transfer-Encoding", "chunked")
+	src.Set("Host", "example.com")
+	src.Set("Content-Length", "123")
+
+	// Connection declares additional hop-by-hop header names (must be filtered)
+	src.Add("Connection", "X-Hop, keep-alive")
+	src.Set("X-Hop", "1")
+
+	deny := buildPassThroughHeaderDenySet(src, nil)
+	dst := http.Header{}
+	copyHeadersExcept(dst, src, deny)
+
+	// allowed
+	if got := dst.Get("X-Trace-Id"); got != "abc" {
+		t.Fatalf("expected X-Trace-Id=abc, got %q", got)
+	}
+	if got := dst.Values("X-Multi"); !reflect.DeepEqual(got, []string{"a", "b"}) {
+		t.Fatalf("expected X-Multi=[a b], got %#v", got)
+	}
+
+	// denied
+	for _, k := range []string{
+		"Authorization",
+		"Api-Key",
+		"X-Api-Key",
+		"Connection",
+		"Upgrade",
+		"Transfer-Encoding",
+		"Host",
+		"Content-Length",
+		"X-Hop",
+	} {
+		if len(dst.Values(k)) != 0 {
+			t.Fatalf("expected %s to be filtered, got %#v", k, dst.Values(k))
+		}
+	}
+}
+
+func TestBuildPassThroughHeaderDenySet_ConnectionTokensAndExtraDeny(t *testing.T) {
+	src := http.Header{}
+	src.Add("Connection", " X-Hop , Foo ")
+
+	deny := buildPassThroughHeaderDenySet(src, []string{"Sec-WebSocket-Key"})
+
+	for _, k := range []string{"x-hop", "foo", "sec-websocket-key"} {
+		if _, ok := deny[k]; !ok {
+			t.Fatalf("expected denyset to include %q", k)
+		}
+	}
+}

--- a/web/src/components/table/channels/modals/EditChannelModal.jsx
+++ b/web/src/components/table/channels/modals/EditChannelModal.jsx
@@ -150,6 +150,7 @@ const EditChannelModal = (props) => {
     force_format: false,
     thinking_to_content: false,
     proxy: '',
+    pass_through_header_enabled: false,
     pass_through_body_enabled: false,
     system_prompt: '',
     system_prompt_override: false,
@@ -372,6 +373,7 @@ const EditChannelModal = (props) => {
     force_format: false,
     thinking_to_content: false,
     proxy: '',
+    pass_through_header_enabled: false,
     pass_through_body_enabled: false,
     system_prompt: '',
   });
@@ -543,6 +545,8 @@ const EditChannelModal = (props) => {
           data.thinking_to_content =
             parsedSettings.thinking_to_content || false;
           data.proxy = parsedSettings.proxy || '';
+          data.pass_through_header_enabled =
+            parsedSettings.pass_through_header_enabled || false;
           data.pass_through_body_enabled =
             parsedSettings.pass_through_body_enabled || false;
           data.system_prompt = parsedSettings.system_prompt || '';
@@ -553,6 +557,7 @@ const EditChannelModal = (props) => {
           data.force_format = false;
           data.thinking_to_content = false;
           data.proxy = '';
+          data.pass_through_header_enabled = false;
           data.pass_through_body_enabled = false;
           data.system_prompt = '';
           data.system_prompt_override = false;
@@ -561,6 +566,7 @@ const EditChannelModal = (props) => {
         data.force_format = false;
         data.thinking_to_content = false;
         data.proxy = '';
+        data.pass_through_header_enabled = false;
         data.pass_through_body_enabled = false;
         data.system_prompt = '';
         data.system_prompt_override = false;
@@ -629,6 +635,7 @@ const EditChannelModal = (props) => {
         force_format: data.force_format,
         thinking_to_content: data.thinking_to_content,
         proxy: data.proxy,
+        pass_through_header_enabled: data.pass_through_header_enabled,
         pass_through_body_enabled: data.pass_through_body_enabled,
         system_prompt: data.system_prompt,
         system_prompt_override: data.system_prompt_override || false,
@@ -909,6 +916,7 @@ const EditChannelModal = (props) => {
       force_format: false,
       thinking_to_content: false,
       proxy: '',
+      pass_through_header_enabled: false,
       pass_through_body_enabled: false,
       system_prompt: '',
       system_prompt_override: false,
@@ -1195,6 +1203,7 @@ const EditChannelModal = (props) => {
       force_format: localInputs.force_format || false,
       thinking_to_content: localInputs.thinking_to_content || false,
       proxy: localInputs.proxy || '',
+      pass_through_header_enabled: localInputs.pass_through_header_enabled || false,
       pass_through_body_enabled: localInputs.pass_through_body_enabled || false,
       system_prompt: localInputs.system_prompt || '',
       system_prompt_override: localInputs.system_prompt_override || false,
@@ -1246,6 +1255,7 @@ const EditChannelModal = (props) => {
     delete localInputs.force_format;
     delete localInputs.thinking_to_content;
     delete localInputs.proxy;
+    delete localInputs.pass_through_header_enabled;
     delete localInputs.pass_through_body_enabled;
     delete localInputs.system_prompt;
     delete localInputs.system_prompt_override;
@@ -3032,6 +3042,22 @@ const EditChannelModal = (props) => {
                       }
                       extraText={t(
                         '将 reasoning_content 转换为 <think> 标签拼接到内容中',
+                      )}
+                    />
+
+                    <Form.Switch
+                      field='pass_through_header_enabled'
+                      label={t('透传请求头')}
+                      checkedText={t('开')}
+                      uncheckedText={t('关')}
+                      onChange={(value) =>
+                        handleChannelSettingsChange(
+                          'pass_through_header_enabled',
+                          value,
+                        )
+                      }
+                      extraText={t(
+                        '透传下游请求头到上游（自动排除 Authorization/api-key/x-api-key 并过滤 hop-by-hop 控制头）',
                       )}
                     />
 


### PR DESCRIPTION
## Summary
- Add per-channel pass-through request headers toggle (UI + settings)
- Forward downstream headers to upstream for HTTP/multipart/WebSocket/Task while filtering auth and hop-by-hop headers
- Add unit tests for denylist and Connection token handling

## Test plan
- [x] go test ./...
- [ ] Enable \"透传请求头\" and confirm User-Agent/trace headers are forwarded
- [ ] Confirm Authorization/api-key/x-api-key are NOT forwarded and channel auth still applies
- [ ] Confirm WebSocket realtime handshake works when enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为通道级别的配置添加了新的请求头透传设置，支持有条件地转发HTTP请求头，并自动过滤敏感和跳跃型请求头。
  * 在通道额外设置面板中新增了一个切换开关，方便启用或禁用请求头透传功能。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->