### PR TITLE
fix(model): ensure log migrations run when LOG_SQL_DSN is empty

### DIFF
--- a/model/main.go
+++ b/model/main.go
@@ -213,7 +213,12 @@ func InitDB() (err error) {
 func InitLogDB() (err error) {
 	if os.Getenv("LOG_SQL_DSN") == "" {
 		LOG_DB = DB
-		return
+		if !common.IsMasterNode {
+			return nil
+		}
+		common.SysLog("database migration started")
+		err = migrateLOGDB()
+		return err
 	}
 	db, err := chooseDB("LOG_SQL_DSN", true)
 	if err == nil {

--- a/model/main.go
+++ b/model/main.go
@@ -216,7 +216,7 @@ func InitLogDB() (err error) {
 		if !common.IsMasterNode {
 			return nil
 		}
-		common.SysLog("database migration started")
+		common.SysLog("log database migration started")
 		err = migrateLOGDB()
 		return err
 	}
@@ -243,7 +243,7 @@ func InitLogDB() (err error) {
 		if !common.IsMasterNode {
 			return nil
 		}
-		common.SysLog("database migration started")
+		common.SysLog("log database migration started")
 		err = migrateLOGDB()
 		return err
 	} else {


### PR DESCRIPTION
## Summary
- When `LOG_SQL_DSN` is empty (LOG_DB shares main DB), run `migrateLOGDB()` on master nodes to ensure `log_details` is migrated.
- Prevents missing `LogDetail`/`log_details` migrations in single-DB deployments.

## Test plan
- `go test ./...` (requires `web/dist` to exist due to `//go:embed web/dist`; build frontend first if needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 改进日志数据库迁移流程：当日志连接信息缺失时，非主节点会跳过迁移；主节点会记录“日志数据库迁移开始”并执行迁移操作，防止在非主节点上误触发迁移。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->